### PR TITLE
build: Add build command and release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: https://registry.npmjs.org
+
+      # Get the 'version' field out of the package.json file
+      - name: Get package.json version
+        id: package-json-version
+        run: echo "version=v$(cat package.json | jq '.version' --raw-output)" >> $GITHUB_OUTPUT
+
+      # Abort if the version in the package.json file doesn't match the tag name of the release
+      - name: Check package.json version against tag name
+        if: steps.package-json-version.outputs.version != github.event.release.tag_name
+        uses: actions/github-script@v3
+        with:
+          script: core.setFailed('Release tag does not match package.json version!')
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build the package
+        run: npm run build
+
+      - name: Create Publish to npm
+        run: npm publish --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/build.js
+++ b/build.js
@@ -1,10 +1,10 @@
 const esbuild = require('esbuild');
 
-const baseConfig = {
+let baseConfig = {
 	entryPoints: ['src/index.ts'],
 	bundle: true,
 	logLevel: 'info',
-	watch: true
+	watch: process.argv[2] === '--watch',
 };
 
 const umdConfig = {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "build/webm-muxer.d.ts"
   ],
   "scripts": {
-    "watch": "node build.js",
+    "build": "node build.js",
+    "watch": "node build.js --watch",
     "check": "npx tsc --noEmit --skipLibCheck",
     "lint": "npx eslint src demo build"
   },


### PR DESCRIPTION
We do 2 things here:

1. Add a non-watch build command to the package.json / build.js
2. Add a workflow to publish the package to npm with provenance enabled

This will help build trust in the release artifacts and provide transparency.
See more here: https://docs.npmjs.com/generating-provenance-statements

You will now need to tag releases and create a release on GitHub to trigger a build.
Additionally, you will need to setup the `NPM_TOKEN` secret with an API token for npm.

Thanks!